### PR TITLE
Remove csrf diable

### DIFF
--- a/src/main/kotlin/no/digdir/catalog_comments_service/security/SecurityConfig.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/security/SecurityConfig.kt
@@ -35,7 +35,6 @@ open class SecurityConfig(
                     config
                 }
             }
-            csrf { disable() }
             authorizeHttpRequests {
                 authorize(HttpMethod.OPTIONS, "/**", permitAll)
                 authorize(HttpMethod.GET, "/ping", permitAll)


### PR DESCRIPTION
Sånn eg har forstått det er det unødvendig å ha med denne linjen då Spring ikkje bryr seg med CSRF så lenge det er eit JWT bearer token i request. 