### PR TITLE
feat: add catalog controller endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## Project Overview
+
+Catalog Comments Service is a Kotlin/Spring Boot 4 microservice that provides a REST API for managing comments on datasets, dataservices, concepts, and services. It uses MongoDB for persistence and OAuth2/JWT for authentication.
+
+## Build and Development Commands
+
+```bash
+# Build and package
+mvn clean package
+
+# Run locally (requires MongoDB via docker compose)
+docker compose up -d
+mvn spring-boot:run -Dspring-boot.run.profiles=develop
+
+# Run all tests with coverage
+mvn verify
+
+# Run only unit tests
+mvn test
+
+# Run only integration tests
+mvn failsafe:integration-test
+
+# Run a single test class
+mvn test -Dtest=CommentServiceTest
+
+# Run a single test method
+mvn test -Dtest=CommentServiceTest#testMethodName
+```
+
+## Architecture
+
+**Layered structure:**
+- `controller/` - REST endpoints with `@PreAuthorize` security annotations
+- `service/` - Business logic and DTO/DBO mapping
+- `repository/` - Spring Data MongoDB DAOs
+- `model/` - Separate DTO (API) and DBO (database) representations
+- `security/` - OAuth2 JWT configuration and custom `Authorizer` for role-based access
+
+**API endpoints** follow pattern `/{orgNumber}/{topicId}/comment` with CRUD operations.
+
+**Authorization roles:**
+- `system:root:admin` - Full system access
+- `organization:{orgNumber}:{admin|write|read}` - Organization-scoped access
+
+## Testing
+
+Tests are organized by type and tagged:
+- `src/test/kotlin/.../unit/` - Unit tests (`@Tag("unit")`) with mocked dependencies
+- `src/test/kotlin/.../integration/` - Integration tests (`@Tag("integration")`) using TestContainers for MongoDB
+
+Key test utilities:
+- `ApiTestContext` - Base class for integration tests, manages TestContainers and mock OIDC server
+- `TestData.kt` - Test fixtures and constants
+- `JwtUtils.kt` - JWT token generation for OAuth2 testing
+
+## Configuration
+
+Spring profiles in `application.yml`:
+- `develop` - Local development (localhost MongoDB, wildcard CORS)
+- `integration-test` - CI testing with TestContainers and mock OIDC at localhost:5050
+
+Environment variables: `MONGODB_HOST`, `MONGODB_USER`, `MONGODB_PASSWORD`, `OIDC_JWKS`, `OIDC_ISSUER`, `CORS_ORIGIN_PATTERNS`
+
+## Tech Stack
+
+- Java 21, Kotlin 2.2, Spring Boot 4.0
+- MongoDB with Spring Data
+- OAuth2 Resource Server with Nimbus JOSE+JWT
+- JUnit 5, Mockito-Kotlin, WireMock, TestContainers
+- SpringDoc OpenAPI (Swagger UI at `/swagger-ui/index.html`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Catalog Comments Service is a Kotlin/Spring Boot 4 microservice that provides a REST API for managing comments on datasets, dataservices, concepts, and services. It uses MongoDB for persistence and OAuth2/JWT for authentication.
+
+## Build and Development Commands
+
+```bash
+# Build and package
+mvn clean package
+
+# Run locally (requires MongoDB via docker compose)
+docker compose up -d
+mvn spring-boot:run -Dspring-boot.run.profiles=develop
+
+# Run all tests with coverage
+mvn verify
+
+# Run only unit tests
+mvn test
+
+# Run only integration tests
+mvn failsafe:integration-test
+
+# Run a single test class
+mvn test -Dtest=CommentServiceTest
+
+# Run a single test method
+mvn test -Dtest=CommentServiceTest#testMethodName
+```
+
+## Architecture
+
+**Layered structure:**
+- `controller/` - REST endpoints with `@PreAuthorize` security annotations
+- `service/` - Business logic and DTO/DBO mapping
+- `repository/` - Spring Data MongoDB DAOs
+- `model/` - Separate DTO (API) and DBO (database) representations
+- `security/` - OAuth2 JWT configuration and custom `Authorizer` for role-based access
+
+**API endpoints** follow pattern `/{orgNumber}/{topicId}/comment` with CRUD operations.
+
+**Authorization roles:**
+- `system:root:admin` - Full system access
+- `organization:{orgNumber}:{admin|write|read}` - Organization-scoped access
+
+## Testing
+
+Tests are organized by type and tagged:
+- `src/test/kotlin/.../unit/` - Unit tests (`@Tag("unit")`) with mocked dependencies
+- `src/test/kotlin/.../integration/` - Integration tests (`@Tag("integration")`) using TestContainers for MongoDB
+
+Key test utilities:
+- `ApiTestContext` - Base class for integration tests, manages TestContainers and mock OIDC server
+- `TestData.kt` - Test fixtures and constants
+- `JwtUtils.kt` - JWT token generation for OAuth2 testing
+
+## Configuration
+
+Spring profiles in `application.yml`:
+- `develop` - Local development (localhost MongoDB, wildcard CORS)
+- `integration-test` - CI testing with TestContainers and mock OIDC at localhost:5050
+
+Environment variables: `MONGODB_HOST`, `MONGODB_USER`, `MONGODB_PASSWORD`, `OIDC_JWKS`, `OIDC_ISSUER`, `CORS_ORIGIN_PATTERNS`
+
+## Tech Stack
+
+- Java 21, Kotlin 2.2, Spring Boot 4.0
+- MongoDB with Spring Data
+- OAuth2 Resource Server with Nimbus JOSE+JWT
+- JUnit 5, Mockito-Kotlin, WireMock, TestContainers
+- SpringDoc OpenAPI (Swagger UI at `/swagger-ui/index.html`)

--- a/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
@@ -1,0 +1,27 @@
+package no.digdir.catalog_comments_service.controller
+
+import no.digdir.catalog_comments_service.model.Comment
+import no.digdir.catalog_comments_service.service.CommentService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@CrossOrigin
+@RequestMapping("/{orgNumber}")
+class CatalogController(private val commentService: CommentService) {
+
+    @PreAuthorize("@authorizer.hasOrgReadPermission(#jwt, #orgNumber)")
+    @GetMapping
+    fun getComments(
+        @AuthenticationPrincipal jwt: Jwt,
+        @PathVariable orgNumber: String
+    ): ResponseEntity<List<Comment>> =
+        ResponseEntity(
+            commentService.getCommentsByOrgNumber(orgNumber),
+            HttpStatus.OK
+        )
+}

--- a/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
+++ b/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
@@ -1,0 +1,94 @@
+package no.digdir.catalog_comments_service.integration
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.digdir.catalog_comments_service.model.Comment
+import no.digdir.catalog_comments_service.utils.ApiTestContext
+import no.digdir.catalog_comments_service.utils.ORG_NUMBER
+import no.digdir.catalog_comments_service.utils.WRONG_ORG_NUMBER
+import no.digdir.catalog_comments_service.utils.authorizedRequest
+import no.digdir.catalog_comments_service.utils.jwk.Access
+import no.digdir.catalog_comments_service.utils.jwk.JwtToken
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ContextConfiguration
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val mapper: ObjectMapper = jacksonObjectMapper()
+    .registerModule(
+        JavaTimeModule()
+            .addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+    )
+    .registerModule(Jdk8Module())
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(
+    properties = ["spring.profiles.active=integration-test"],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ContextConfiguration(initializers = [ApiTestContext.Initializer::class])
+@Tag("integration")
+class CatalogIntegration : ApiTestContext() {
+
+    @Test
+    fun `Unauthorized when access token is not included`() {
+        val rsp = authorizedRequest("/$ORG_NUMBER", port, "", null, HttpMethod.GET)
+        assertEquals(HttpStatus.UNAUTHORIZED.value(), rsp["status"])
+    }
+
+    @Test
+    fun `Forbidden when requesting comments for org without read access`() {
+        val rsp = authorizedRequest(
+            "/$WRONG_ORG_NUMBER", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.FORBIDDEN.value(), rsp["status"])
+    }
+
+    @Test
+    fun `Ok - Returns all comments for organization with read access`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
+        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+    }
+
+    @Test
+    fun `Ok - Returns all comments for organization with write access`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER", port, "",
+            JwtToken(Access.ORG_WRITE).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
+        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+    }
+
+    @Test
+    fun `Ok - Returns all comments for organization with root access`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER", port, "",
+            JwtToken(Access.ROOT).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
+        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+    }
+}


### PR DESCRIPTION
# Summary fixes #170

- Add `CatalogController` with `GET /{orgNumber}` endpoint
- Returns all comments for an organization
- Requires OAuth2 read permission via `@PreAuthorize`
- Add integration tests for authorization scenarios
- Add CLAUDE.md and AGENTS.md configuration files