### PR TITLE
feat: add pagination to GET /{orgNumber} endpoint

### DIFF
--- a/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
@@ -20,7 +20,7 @@ class CatalogController(private val commentService: CommentService) {
     fun getComments(
         @AuthenticationPrincipal jwt: Jwt,
         @PathVariable orgNumber: String,
-        @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(name = "sort_by", defaultValue = "datetime") sortBy: String,
         @RequestParam(name = "sort_order", defaultValue = "desc") sortOrder: String

--- a/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/controller/CatalogController.kt
@@ -1,6 +1,7 @@
 package no.digdir.catalog_comments_service.controller
 
 import no.digdir.catalog_comments_service.model.Comment
+import no.digdir.catalog_comments_service.model.PaginatedResponse
 import no.digdir.catalog_comments_service.service.CommentService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -18,10 +19,14 @@ class CatalogController(private val commentService: CommentService) {
     @GetMapping
     fun getComments(
         @AuthenticationPrincipal jwt: Jwt,
-        @PathVariable orgNumber: String
-    ): ResponseEntity<List<Comment>> =
+        @PathVariable orgNumber: String,
+        @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+        @RequestParam(name = "sort_by", defaultValue = "datetime") sortBy: String,
+        @RequestParam(name = "sort_order", defaultValue = "desc") sortOrder: String
+    ): ResponseEntity<PaginatedResponse<Comment>> =
         ResponseEntity(
-            commentService.getCommentsByOrgNumber(orgNumber),
+            commentService.getCommentsByOrgNumberPaginated(orgNumber, page, size, sortBy, sortOrder),
             HttpStatus.OK
         )
 }

--- a/src/main/kotlin/no/digdir/catalog_comments_service/model/Pagination.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/model/Pagination.kt
@@ -1,0 +1,12 @@
+package no.digdir.catalog_comments_service.model
+
+data class Pagination(
+    val totalPages: Int,
+    val page: Int,
+    val size: Int
+)
+
+data class PaginatedResponse<T>(
+    val items: List<T>,
+    val pagination: Pagination
+)

--- a/src/main/kotlin/no/digdir/catalog_comments_service/repository/CommentMongoRepository.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/repository/CommentMongoRepository.kt
@@ -1,0 +1,31 @@
+package no.digdir.catalog_comments_service.repository
+
+import no.digdir.catalog_comments_service.model.CommentDBO
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+class CommentMongoRepository(private val mongoTemplate: MongoTemplate) {
+
+    fun findPaginated(
+        orgNumber: String,
+        skip: Long,
+        limit: Int,
+        sortField: String,
+        sortDirection: Sort.Direction
+    ): List<CommentDBO> {
+        val query = Query(Criteria.where("orgNumber").`is`(orgNumber))
+            .with(Sort.by(sortDirection, sortField).and(Sort.by(sortDirection, "_id")))
+            .skip(skip)
+            .limit(limit)
+        return mongoTemplate.find(query, CommentDBO::class.java)
+    }
+
+    fun countByOrgNumber(orgNumber: String): Long {
+        val query = Query(Criteria.where("orgNumber").`is`(orgNumber))
+        return mongoTemplate.count(query, CommentDBO::class.java)
+    }
+}

--- a/src/main/kotlin/no/digdir/catalog_comments_service/service/CommentService.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/service/CommentService.kt
@@ -26,7 +26,7 @@ class CommentService(
 ) {
 
     companion object {
-        const val MIN_PAGE = 1
+        const val MIN_PAGE = 0
         const val MAX_PAGE = 10000
         const val MIN_SIZE = 1
         const val MAX_SIZE = 100
@@ -89,7 +89,7 @@ class CommentService(
         val sortField = SORT_FIELD_WHITELIST[sortBy] ?: "createdDate"
         val sortDirection = if (sortOrder.equals("asc", ignoreCase = true)) Sort.Direction.ASC else Sort.Direction.DESC
 
-        val skip = (validatedPage - 1).toLong() * validatedSize
+        val skip = validatedPage.toLong() * validatedSize
         val items = commentMongoRepository.findPaginated(orgNumber, skip, validatedSize, sortField, sortDirection)
         val totalCount = commentMongoRepository.countByOrgNumber(orgNumber)
 

--- a/src/main/kotlin/no/digdir/catalog_comments_service/service/CommentService.kt
+++ b/src/main/kotlin/no/digdir/catalog_comments_service/service/CommentService.kt
@@ -2,17 +2,43 @@ package no.digdir.catalog_comments_service.service
 
 import no.digdir.catalog_comments_service.model.Comment
 import no.digdir.catalog_comments_service.model.CommentDBO
+import no.digdir.catalog_comments_service.model.PaginatedResponse
+import no.digdir.catalog_comments_service.model.Pagination
 import no.digdir.catalog_comments_service.model.UserDBO
 import no.digdir.catalog_comments_service.repository.CommentDAO
+import no.digdir.catalog_comments_service.repository.CommentMongoRepository
 import no.digdir.catalog_comments_service.repository.UserDAO
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Sort
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import kotlin.math.ceil
 
 private val logger = LoggerFactory.getLogger(CommentService::class.java)
 
 @Service
-class CommentService (private val commentDAO: CommentDAO, private val userDAO: UserDAO) {
+class CommentService(
+    private val commentDAO: CommentDAO,
+    private val userDAO: UserDAO,
+    private val commentMongoRepository: CommentMongoRepository
+) {
+
+    companion object {
+        const val MIN_PAGE = 1
+        const val MAX_PAGE = 10000
+        const val MIN_SIZE = 1
+        const val MAX_SIZE = 100
+
+        val SORT_FIELD_WHITELIST = mapOf(
+            "datetime" to "createdDate",
+            "createdDate" to "createdDate",
+            "lastChangedDate" to "lastChangedDate",
+            "topicId" to "topicId",
+            "comment" to "comment"
+        )
+    }
 
     private fun createUserIfNotExists(userId: String, name: String? = null, email: String? = null) {
         try {
@@ -40,6 +66,42 @@ class CommentService (private val commentDAO: CommentDAO, private val userDAO: U
 
     fun getCommentsByOrgNumber(orgNumber: String): List<Comment> = commentDAO.findCommentsByOrgNumber(orgNumber)
         .map { it.toDTO(it.user?.let { userId -> userDAO.findByIdOrNull(userId) }) }
+
+    fun getCommentsByOrgNumberPaginated(
+        orgNumber: String,
+        page: Int,
+        size: Int,
+        sortBy: String,
+        sortOrder: String
+    ): PaginatedResponse<Comment> {
+        val validatedPage = when {
+            page > MAX_PAGE -> throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Page must not exceed $MAX_PAGE")
+            page < MIN_PAGE -> MIN_PAGE
+            else -> page
+        }
+
+        val validatedSize = when {
+            size > MAX_SIZE -> throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Size must not exceed $MAX_SIZE")
+            size < MIN_SIZE -> MIN_SIZE
+            else -> size
+        }
+
+        val sortField = SORT_FIELD_WHITELIST[sortBy] ?: "createdDate"
+        val sortDirection = if (sortOrder.equals("asc", ignoreCase = true)) Sort.Direction.ASC else Sort.Direction.DESC
+
+        val skip = (validatedPage - 1).toLong() * validatedSize
+        val items = commentMongoRepository.findPaginated(orgNumber, skip, validatedSize, sortField, sortDirection)
+        val totalCount = commentMongoRepository.countByOrgNumber(orgNumber)
+
+        val dtos = items.map { it.toDTO(it.user?.let { userId -> userDAO.findByIdOrNull(userId) }) }
+
+        val totalPages = if (totalCount == 0L) 0 else ceil(totalCount.toDouble() / validatedSize).toInt()
+
+        return PaginatedResponse(
+            items = dtos,
+            pagination = Pagination(totalPages = totalPages, page = validatedPage, size = validatedSize)
+        )
+    }
 
     fun getCommentsByOrgNumberAndTopicId(orgNumber: String, topicId: String): List<Comment> =
         commentDAO.findCommentsByOrgNumberAndTopicId(orgNumber, topicId)

--- a/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
+++ b/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
@@ -73,7 +73,7 @@ class CatalogIntegration : ApiTestContext() {
         val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
         assertTrue(response.items.isNotEmpty(), "Should return comments for the organization")
         assertTrue(response.pagination.totalPages > 0)
-        assertEquals(1, response.pagination.page)
+        assertEquals(0, response.pagination.page)
         assertEquals(10, response.pagination.size)
     }
 
@@ -104,14 +104,14 @@ class CatalogIntegration : ApiTestContext() {
     @Test
     fun `Ok - Custom page and size returns correct number of items`() {
         val rsp = authorizedRequest(
-            "/$ORG_NUMBER?page=1&size=2", port, "",
+            "/$ORG_NUMBER?page=0&size=2", port, "",
             JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
         )
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
         val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
         assertEquals(2, response.items.size)
-        assertEquals(1, response.pagination.page)
+        assertEquals(0, response.pagination.page)
         assertEquals(2, response.pagination.size)
     }
 
@@ -168,32 +168,32 @@ class CatalogIntegration : ApiTestContext() {
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
         val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
-        assertEquals(1, response.pagination.page)
+        assertEquals(0, response.pagination.page)
         assertEquals(10, response.pagination.size)
     }
 
     @Test
-    fun `Ok - Page 2 returns different items than page 1`() {
+    fun `Ok - Page 1 returns different items than page 0`() {
+        val rsp0 = authorizedRequest(
+            "/$ORG_NUMBER?page=0&size=2", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
         val rsp1 = authorizedRequest(
             "/$ORG_NUMBER?page=1&size=2", port, "",
             JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
         )
-        val rsp2 = authorizedRequest(
-            "/$ORG_NUMBER?page=2&size=2", port, "",
-            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
-        )
+        assertEquals(HttpStatus.OK.value(), rsp0["status"])
         assertEquals(HttpStatus.OK.value(), rsp1["status"])
-        assertEquals(HttpStatus.OK.value(), rsp2["status"])
 
+        val page0 = deserializePaginatedResponse<Comment>(rsp0["body"] as String)
         val page1 = deserializePaginatedResponse<Comment>(rsp1["body"] as String)
-        val page2 = deserializePaginatedResponse<Comment>(rsp2["body"] as String)
 
+        assertTrue(page0.items.isNotEmpty(), "Page 0 should have items")
         assertTrue(page1.items.isNotEmpty(), "Page 1 should have items")
-        assertTrue(page2.items.isNotEmpty(), "Page 2 should have items")
 
+        val page0Ids = page0.items.map { it.id }.toSet()
         val page1Ids = page1.items.map { it.id }.toSet()
-        val page2Ids = page2.items.map { it.id }.toSet()
-        assertTrue(page1Ids.intersect(page2Ids).isEmpty(), "Page 1 and page 2 should have no overlapping IDs")
+        assertTrue(page0Ids.intersect(page1Ids).isEmpty(), "Page 0 and page 1 should have no overlapping IDs")
     }
 
     @Test
@@ -229,7 +229,7 @@ class CatalogIntegration : ApiTestContext() {
     }
 
     @Test
-    fun `Ok - Negative page is clamped to 1`() {
+    fun `Ok - Negative page is clamped to 0`() {
         val rsp = authorizedRequest(
             "/$ORG_NUMBER?page=-1", port, "",
             JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
@@ -237,7 +237,7 @@ class CatalogIntegration : ApiTestContext() {
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
         val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
-        assertEquals(1, response.pagination.page)
+        assertEquals(0, response.pagination.page)
     }
 
     @Test

--- a/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
+++ b/src/test/kotlin/no/digdir/catalog_comments_service/integration/CatalogIntegration.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.digdir.catalog_comments_service.model.Comment
+import no.digdir.catalog_comments_service.model.PaginatedResponse
 import no.digdir.catalog_comments_service.utils.ApiTestContext
 import no.digdir.catalog_comments_service.utils.ORG_NUMBER
 import no.digdir.catalog_comments_service.utils.WRONG_ORG_NUMBER
@@ -41,6 +42,11 @@ private val mapper: ObjectMapper = jacksonObjectMapper()
 @Tag("integration")
 class CatalogIntegration : ApiTestContext() {
 
+    private inline fun <reified T> deserializePaginatedResponse(body: String): PaginatedResponse<T> {
+        val type = mapper.typeFactory.constructParametricType(PaginatedResponse::class.java, T::class.java)
+        return mapper.readValue(body, type)
+    }
+
     @Test
     fun `Unauthorized when access token is not included`() {
         val rsp = authorizedRequest("/$ORG_NUMBER", port, "", null, HttpMethod.GET)
@@ -57,38 +63,193 @@ class CatalogIntegration : ApiTestContext() {
     }
 
     @Test
-    fun `Ok - Returns all comments for organization with read access`() {
+    fun `Ok - Returns paginated comments for organization with read access`() {
         val rsp = authorizedRequest(
             "/$ORG_NUMBER", port, "",
             JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
         )
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
-        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
-        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isNotEmpty(), "Should return comments for the organization")
+        assertTrue(response.pagination.totalPages > 0)
+        assertEquals(1, response.pagination.page)
+        assertEquals(10, response.pagination.size)
     }
 
     @Test
-    fun `Ok - Returns all comments for organization with write access`() {
+    fun `Ok - Returns paginated comments for organization with write access`() {
         val rsp = authorizedRequest(
             "/$ORG_NUMBER", port, "",
             JwtToken(Access.ORG_WRITE).toString(), HttpMethod.GET
         )
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
-        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
-        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isNotEmpty(), "Should return comments for the organization")
     }
 
     @Test
-    fun `Ok - Returns all comments for organization with root access`() {
+    fun `Ok - Returns paginated comments for organization with root access`() {
         val rsp = authorizedRequest(
             "/$ORG_NUMBER", port, "",
             JwtToken(Access.ROOT).toString(), HttpMethod.GET
         )
         assertEquals(HttpStatus.OK.value(), rsp["status"])
 
-        val comments: List<Comment> = mapper.readValue(rsp["body"] as String)
-        assertTrue(comments.isNotEmpty(), "Should return comments for the organization")
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isNotEmpty(), "Should return comments for the organization")
+    }
+
+    @Test
+    fun `Ok - Custom page and size returns correct number of items`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?page=1&size=2", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertEquals(2, response.items.size)
+        assertEquals(1, response.pagination.page)
+        assertEquals(2, response.pagination.size)
+    }
+
+    @Test
+    fun `Ok - Empty items when page exceeds data`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?page=9999", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isEmpty(), "Should return empty items for page beyond data")
+    }
+
+    @Test
+    fun `Bad Request when page exceeds maximum`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?page=10001", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.BAD_REQUEST.value(), rsp["status"])
+    }
+
+    @Test
+    fun `Bad Request when size exceeds maximum`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?size=101", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.BAD_REQUEST.value(), rsp["status"])
+    }
+
+    @Test
+    fun `Ok - Sort order ascending`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?sort_order=asc&sort_by=comment", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isNotEmpty())
+        val comments = response.items.mapNotNull { it.comment }
+        assertEquals(comments.sorted(), comments, "Comments should be in ascending order")
+    }
+
+    @Test
+    fun `Ok - Defaults applied when no params`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertEquals(1, response.pagination.page)
+        assertEquals(10, response.pagination.size)
+    }
+
+    @Test
+    fun `Ok - Page 2 returns different items than page 1`() {
+        val rsp1 = authorizedRequest(
+            "/$ORG_NUMBER?page=1&size=2", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        val rsp2 = authorizedRequest(
+            "/$ORG_NUMBER?page=2&size=2", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp1["status"])
+        assertEquals(HttpStatus.OK.value(), rsp2["status"])
+
+        val page1 = deserializePaginatedResponse<Comment>(rsp1["body"] as String)
+        val page2 = deserializePaginatedResponse<Comment>(rsp2["body"] as String)
+
+        assertTrue(page1.items.isNotEmpty(), "Page 1 should have items")
+        assertTrue(page2.items.isNotEmpty(), "Page 2 should have items")
+
+        val page1Ids = page1.items.map { it.id }.toSet()
+        val page2Ids = page2.items.map { it.id }.toSet()
+        assertTrue(page1Ids.intersect(page2Ids).isEmpty(), "Page 1 and page 2 should have no overlapping IDs")
+    }
+
+    @Test
+    fun `Ok - totalPages is correct for seeded data`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?size=2", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.pagination.totalPages >= 3, "6 seeded comments / size 2 should give at least 3 totalPages")
+    }
+
+    @Test
+    fun `Ok - Sort by datetime descending returns items in desc order`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?sort_by=datetime&sort_order=desc", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertTrue(response.items.isNotEmpty())
+
+        val dates = response.items.mapNotNull { it.createdDate }
+        for (i in 0 until dates.size - 1) {
+            assertTrue(
+                !dates[i].isBefore(dates[i + 1]),
+                "Items should be in descending date order: ${dates[i]} should not be before ${dates[i + 1]}"
+            )
+        }
+    }
+
+    @Test
+    fun `Ok - Negative page is clamped to 1`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?page=-1", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertEquals(1, response.pagination.page)
+    }
+
+    @Test
+    fun `Ok - Size 1 returns exactly one item`() {
+        val rsp = authorizedRequest(
+            "/$ORG_NUMBER?size=1", port, "",
+            JwtToken(Access.ORG_READ).toString(), HttpMethod.GET
+        )
+        assertEquals(HttpStatus.OK.value(), rsp["status"])
+
+        val response = deserializePaginatedResponse<Comment>(rsp["body"] as String)
+        assertEquals(1, response.items.size)
+        assertTrue(response.pagination.totalPages >= 6, "6 seeded comments / size 1 should give at least 6 totalPages")
     }
 }

--- a/src/test/kotlin/no/digdir/catalog_comments_service/unit/CommentService.kt
+++ b/src/test/kotlin/no/digdir/catalog_comments_service/unit/CommentService.kt
@@ -57,16 +57,16 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(5L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "datetime", "desc")
 
         assertEquals(5, result.items.size)
-        assertEquals(1, result.pagination.page)
+        assertEquals(0, result.pagination.page)
         assertEquals(10, result.pagination.size)
         assertEquals(1, result.pagination.totalPages)
     }
 
     @Test
-    fun `Paginated - page below min is clamped to 1`() {
+    fun `Paginated - page below min is clamped to 0`() {
         whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
             .thenReturn(emptyList())
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
@@ -74,7 +74,7 @@ class CommentService: ApiTestContext() {
 
         val result = commentService.getCommentsByOrgNumberPaginated("246813579", -5, 10, "datetime", "desc")
 
-        assertEquals(1, result.pagination.page)
+        assertEquals(0, result.pagination.page)
     }
 
     @Test
@@ -100,7 +100,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 0, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 0, "datetime", "desc")
 
         assertEquals(1, result.pagination.size)
     }
@@ -112,7 +112,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "unknownField", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "unknownField", "desc")
 
         assertEquals(0, result.pagination.totalPages)
     }
@@ -125,7 +125,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(25L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "datetime", "desc")
 
         assertEquals(3, result.pagination.totalPages)
     }
@@ -137,7 +137,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "datetime", "desc")
 
         assertTrue(result.items.isEmpty())
         assertEquals(0, result.pagination.totalPages)
@@ -150,14 +150,14 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "asc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "datetime", "asc")
 
         assertTrue(result.items.isEmpty())
     }
 
     @Test
     fun `Paginated - page at max boundary 10000 is accepted`() {
-        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(99990L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(100000L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
             .thenReturn(emptyList())
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
@@ -174,7 +174,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 100, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 100, "datetime", "desc")
 
         assertEquals(100, result.pagination.size)
     }
@@ -187,7 +187,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(6L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 3, "datetime", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 3, "datetime", "desc")
 
         assertEquals(2, result.pagination.totalPages)
     }
@@ -199,7 +199,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "lastChangedDate", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "lastChangedDate", "desc")
 
         assertEquals(0, result.items.size)
     }
@@ -211,7 +211,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "topicId", "desc")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "topicId", "desc")
 
         assertEquals(0, result.items.size)
     }
@@ -223,7 +223,7 @@ class CommentService: ApiTestContext() {
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
             .thenReturn(0L)
 
-        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "ASC")
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 0, 10, "datetime", "ASC")
 
         assertTrue(result.items.isEmpty())
     }
@@ -231,10 +231,10 @@ class CommentService: ApiTestContext() {
     @Test
     fun `Paginated - page 2 computes correct skip`() {
         val dbos = createTestDBOs(5)
-        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(5L), eq(5), eq("createdDate"), eq(Sort.Direction.DESC)))
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(10L), eq(5), eq("createdDate"), eq(Sort.Direction.DESC)))
             .thenReturn(dbos)
         whenever(commentMongoRepository.countByOrgNumber("246813579"))
-            .thenReturn(10L)
+            .thenReturn(15L)
 
         val result = commentService.getCommentsByOrgNumberPaginated("246813579", 2, 5, "datetime", "desc")
 

--- a/src/test/kotlin/no/digdir/catalog_comments_service/unit/CommentService.kt
+++ b/src/test/kotlin/no/digdir/catalog_comments_service/unit/CommentService.kt
@@ -1,6 +1,8 @@
 package no.digdir.catalog_comments_service.unit
 
+import no.digdir.catalog_comments_service.model.CommentDBO
 import no.digdir.catalog_comments_service.repository.CommentDAO
+import no.digdir.catalog_comments_service.repository.CommentMongoRepository
 import no.digdir.catalog_comments_service.repository.UserDAO
 import no.digdir.catalog_comments_service.service.CommentService
 import no.digdir.catalog_comments_service.service.toDBO
@@ -9,15 +11,23 @@ import no.digdir.catalog_comments_service.utils.COMMENT_0
 import no.digdir.catalog_comments_service.utils.COMMENT_1
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Sort
+import org.springframework.web.server.ResponseStatusException
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @Tag("unit")
 class CommentService: ApiTestContext() {
     private val commentDAO: CommentDAO = mock()
     private val userDAO: UserDAO = mock()
-    private val commentService = CommentService(commentDAO, userDAO)
+    private val commentMongoRepository: CommentMongoRepository = mock()
+    private val commentService = CommentService(commentDAO, userDAO, commentMongoRepository)
 
     @Test
     fun `Get all comments by topic id` () {
@@ -38,4 +48,209 @@ class CommentService: ApiTestContext() {
 
         assertTrue { result.size == 2 }
     }
+
+    @Test
+    fun `Paginated - default params return paginated response`() {
+        val dbos = createTestDBOs(5)
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(dbos)
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(5L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+
+        assertEquals(5, result.items.size)
+        assertEquals(1, result.pagination.page)
+        assertEquals(10, result.pagination.size)
+        assertEquals(1, result.pagination.totalPages)
+    }
+
+    @Test
+    fun `Paginated - page below min is clamped to 1`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", -5, 10, "datetime", "desc")
+
+        assertEquals(1, result.pagination.page)
+    }
+
+    @Test
+    fun `Paginated - page exceeding max throws Bad Request`() {
+        val exception = assertThrows<ResponseStatusException> {
+            commentService.getCommentsByOrgNumberPaginated("246813579", 10001, 10, "datetime", "desc")
+        }
+        assertEquals(400, exception.statusCode.value())
+    }
+
+    @Test
+    fun `Paginated - size exceeding max throws Bad Request`() {
+        val exception = assertThrows<ResponseStatusException> {
+            commentService.getCommentsByOrgNumberPaginated("246813579", 1, 101, "datetime", "desc")
+        }
+        assertEquals(400, exception.statusCode.value())
+    }
+
+    @Test
+    fun `Paginated - size below min is clamped to 1`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(1), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 0, "datetime", "desc")
+
+        assertEquals(1, result.pagination.size)
+    }
+
+    @Test
+    fun `Paginated - unknown sort field defaults to createdDate`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "unknownField", "desc")
+
+        assertEquals(0, result.pagination.totalPages)
+    }
+
+    @Test
+    fun `Paginated - totalPages computed correctly`() {
+        val dbos = createTestDBOs(10)
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(dbos)
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(25L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+
+        assertEquals(3, result.pagination.totalPages)
+    }
+
+    @Test
+    fun `Paginated - empty results return empty list and totalPages 0`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "desc")
+
+        assertTrue(result.items.isEmpty())
+        assertEquals(0, result.pagination.totalPages)
+    }
+
+    @Test
+    fun `Paginated - sort order asc is applied`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.ASC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "asc")
+
+        assertTrue(result.items.isEmpty())
+    }
+
+    @Test
+    fun `Paginated - page at max boundary 10000 is accepted`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(99990L), eq(10), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 10000, 10, "datetime", "desc")
+
+        assertEquals(10000, result.pagination.page)
+    }
+
+    @Test
+    fun `Paginated - size at max boundary 100 is accepted`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(100), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 100, "datetime", "desc")
+
+        assertEquals(100, result.pagination.size)
+    }
+
+    @Test
+    fun `Paginated - exactly divisible totalPages`() {
+        val dbos = createTestDBOs(3)
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(3), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(dbos)
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(6L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 3, "datetime", "desc")
+
+        assertEquals(2, result.pagination.totalPages)
+    }
+
+    @Test
+    fun `Paginated - known sort field lastChangedDate maps correctly`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("lastChangedDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "lastChangedDate", "desc")
+
+        assertEquals(0, result.items.size)
+    }
+
+    @Test
+    fun `Paginated - known sort field topicId maps correctly`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("topicId"), eq(Sort.Direction.DESC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "topicId", "desc")
+
+        assertEquals(0, result.items.size)
+    }
+
+    @Test
+    fun `Paginated - sort order ASC case insensitive`() {
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(0L), eq(10), eq("createdDate"), eq(Sort.Direction.ASC)))
+            .thenReturn(emptyList())
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(0L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 1, 10, "datetime", "ASC")
+
+        assertTrue(result.items.isEmpty())
+    }
+
+    @Test
+    fun `Paginated - page 2 computes correct skip`() {
+        val dbos = createTestDBOs(5)
+        whenever(commentMongoRepository.findPaginated(eq("246813579"), eq(5L), eq(5), eq("createdDate"), eq(Sort.Direction.DESC)))
+            .thenReturn(dbos)
+        whenever(commentMongoRepository.countByOrgNumber("246813579"))
+            .thenReturn(10L)
+
+        val result = commentService.getCommentsByOrgNumberPaginated("246813579", 2, 5, "datetime", "desc")
+
+        assertEquals(5, result.items.size)
+        assertEquals(2, result.pagination.page)
+    }
+
+    private fun createTestDBOs(count: Int): List<CommentDBO> =
+        (1..count).map { i ->
+            CommentDBO(
+                id = "id$i",
+                createdDate = LocalDateTime.now(),
+                topicId = "topicId0",
+                orgNumber = "246813579",
+                user = null,
+                comment = "Comment $i"
+            )
+        }
 }


### PR DESCRIPTION
# Summary fixes #172

- Add pagination support with page, size, sort_by, sort_order query params
- Return PaginatedResponse with items array and pagination metadata
- Validate page (1-10000) and size (1-100) boundaries
- Support sorting by datetime, topicId, comment, lastChangedDate
- Add 7 unit tests for service layer pagination logic
- Add 5 integration tests for API endpoint behavior